### PR TITLE
Use CompletableFutures for async update checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simply instantiate a new `UpdateChecker` object with your GitHub username, repos
 
 Then call `.check()` or `.checkAsync()` on the instance to check for updates.
 
-You can then log the update message with `logUpdateMessage()`.
+You can then log the update message with `logUpdateMessage()` or `logUpdateMessageAsync()`.
 
 ```java
 UpdateChecker updateChecker = new UpdateChecker("TechnicJelle", "UpdateCheckerJava", "2.0");
@@ -18,7 +18,3 @@ updateChecker.logUpdateMessage(getLogger());
 ```
 
 Full javadoc API reference: [technicjelle.com/UpdateCheckerJava](https://technicjelle.com/UpdateCheckerJava/com/technicjelle/UpdateChecker.html)
-
-When using the async method, you, or your program's users, can override it to be synchronous anyway,
-by passing `-Dtechnicjelle.updatechecker.noasync` as a JVM argument.\
-Example: `java -Dtechnicjelle.updatechecker.noasync -jar server.jar`

--- a/src/main/java/com/technicjelle/UpdateChecker.java
+++ b/src/main/java/com/technicjelle/UpdateChecker.java
@@ -43,7 +43,8 @@ public class UpdateChecker {
 	 * @see #checkAsync()
 	 */
 	public void check() {
-		getLatestVersion();
+		checkAsync();
+		latestVersionFuture.join();
 	}
 
 	/**

--- a/src/main/java/com/technicjelle/UpdateChecker.java
+++ b/src/main/java/com/technicjelle/UpdateChecker.java
@@ -108,6 +108,16 @@ public class UpdateChecker {
 	}
 
 	/**
+	 * This method logs a message to the console if an update is available, asynchronously<br>
+	 *
+	 * @param logger Logger to log a potential update notification to
+	 */
+	public synchronized void logUpdateMessageAsync(@NotNull Logger logger) {
+		if (latestVersionFuture == null) checkAsync();
+		latestVersionFuture.thenRun(() -> logUpdateMessage(logger));
+	}
+
+	/**
 	 * Removes a potential <code>v</code> prefix from a version
 	 *
 	 * @param version Version to remove the prefix from

--- a/src/main/java/com/technicjelle/UpdateChecker.java
+++ b/src/main/java/com/technicjelle/UpdateChecker.java
@@ -49,8 +49,7 @@ public class UpdateChecker {
 
 	/**
 	 * Checks for updates from a GitHub repository's releases<br>
-	 * <i>This method does not block the thread it is called from</i><br>
-	 * <br>Start your program with <code>-Dtechnicjelle.updatechecker.noasync</code> to disable async, and just always check synchronously
+	 * <i>This method does not block the thread it is called from</i>
 	 * @see #check()
 	 */
 	public void checkAsync() {

--- a/src/main/java/com/technicjelle/UpdateChecker.java
+++ b/src/main/java/com/technicjelle/UpdateChecker.java
@@ -49,6 +49,7 @@ public class UpdateChecker {
 	/**
 	 * Checks for updates from a GitHub repository's releases<br>
 	 * <i>This method does not block the thread it is called from</i>
+	 *
 	 * @see #check()
 	 */
 	public void checkAsync() {
@@ -57,6 +58,7 @@ public class UpdateChecker {
 
 	/**
 	 * Checks if necessary and returns the latest available version
+	 *
 	 * @return the latest available version
 	 */
 	public synchronized String getLatestVersion() {
@@ -87,7 +89,8 @@ public class UpdateChecker {
 	}
 
 	/**
-	 * Checks if necessary and returns weather an update is available or not
+	 * Checks if necessary and returns whether an update is available or not
+	 *
 	 * @return <code>true</code> if there is an update available or <code>false</code> otherwise.
 	 */
 	public boolean isUpdateAvailable() {

--- a/src/main/java/com/technicjelle/UpdateChecker.java
+++ b/src/main/java/com/technicjelle/UpdateChecker.java
@@ -5,11 +5,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
 /**


### PR DESCRIPTION
This PR removes the necessity of calling `check()` manually before logging the update-messages. 
It also moves the async logic to a `CompletableFuture` to make sure that the actual check-call is only done once even if we call `getLatestVersion()` multiple times in quick succession. :)